### PR TITLE
Filter deleted accounts on accounts list

### DIFF
--- a/app/controllers/api/accounts_controller.rb
+++ b/app/controllers/api/accounts_controller.rb
@@ -7,11 +7,7 @@ module Api
     def my_money; end
 
     def index
-      if params[:include_deactivated]
-        render json: Account.all
-      else
-        render json: Account.where(deleted_at: nil)
-      end
+      render json: Account.all
     end
 
     def create

--- a/app/javascript/components/accounts/AccountList.jsx
+++ b/app/javascript/components/accounts/AccountList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getAccounts } from '../../actions/account-actions';
-import accountSelector from '../../selectors/account-selector';
+import { activeAccountSelector } from '../../selectors/account-selector';
 import PageHeader from '../common/PageHeader';
 import NewModelButtons from '../common/controls/NewModelButtons';
 import AccountGroup from './AccountGroup';
@@ -51,7 +51,7 @@ AccountListComponent.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    accountGroups: accountSelector(state).toJS(),
+    accountGroups: activeAccountSelector(state).toJS(),
     accountTypes: state.accountStore.get('accountTypes').toJS(),
     apiStatus: state.apiStatusStore.toJS(),
   };

--- a/app/javascript/selectors/account-selector.js
+++ b/app/javascript/selectors/account-selector.js
@@ -7,8 +7,20 @@ function groupedAccounts(accountTypes, accounts) {
   return accounts.groupBy(account => account.get('accountType'));
 }
 
+function groupedActiveAccounts(accounts) {
+  console.log(accounts.filter(a => a.deletedAt != null).toJS())
+  return accounts
+    .filter(a => a.get('deletedAt') == null)
+    .groupBy(account => account.get('accountType'));
+}
+
 export default createSelector(
   accountTypeSelector,
   accountSelector,
   (accountTypes, accounts) => groupedAccounts(accountTypes, accounts)
+);
+
+export const activeAccountSelector = createSelector(
+  accountSelector,
+  accounts => groupedActiveAccounts(accounts)
 );

--- a/app/javascript/transformers/account-transformer.js
+++ b/app/javascript/transformers/account-transformer.js
@@ -42,6 +42,7 @@ const accountTransformer = {
           openingBalance: account.starting_balance,
           openingBalanceDate: account.starting_date,
           currentBalance: account.current_balance,
+          deletedAt: account.deleted_at,
         };
       case 'share':
         return {
@@ -50,6 +51,7 @@ const accountTransformer = {
           ticker: account.ticker,
           name: account.name,
           currentBalance: account.current_balance,
+          deletedAt: account.deleted_at,
         };
       case 'loan':
         return {
@@ -62,6 +64,7 @@ const accountTransformer = {
           interestRate: account.interest_rate,
           openingBalanceDate: account.starting_date,
           currentBalance: account.current_balance,
+          deletedAt: account.deleted_at,
         };
       default:
         throw new Error('Unknown account type');

--- a/spec/controllers/api/accounts_controller_spec.rb
+++ b/spec/controllers/api/accounts_controller_spec.rb
@@ -4,39 +4,18 @@ require 'rails_helper'
 
 RSpec.describe Api::AccountsController do
   describe 'GET index' do
-    context 'when no params are provided' do
-      let(:params) { {} }
+    it 'returns a list of all active accounts' do
+      account = FactoryBot.create(:account, starting_balance: 1000)
+      deleted_account = FactoryBot.create(:account, deleted_at: '2014-02-02')
 
-      it 'returns a list of all active accounts' do
-        account = FactoryBot.create(:account, starting_balance: 1000)
-        FactoryBot.create(:account, deleted_at: '2014-02-02')
+      get(:index)
 
-        get(:index, params:)
+      expect(response).to have_http_status(:ok)
 
-        expect(response).to have_http_status(:ok)
-
-        json = response.parsed_body
-        expect(json['accounts'].length).to eq(1)
-        expect(json['accounts'][0]).to eq(serialized_account(account))
-      end
-    end
-
-    context 'when deactivated param is provided' do
-      let(:params) { { include_deactivated: true } }
-
-      it 'returns a list of all active accounts' do
-        account = FactoryBot.create(:account, starting_balance: 1000)
-        deactivated_account = FactoryBot.create(:account, deleted_at: '2014-02-02')
-
-        get(:index, params:)
-
-        expect(response).to have_http_status(:ok)
-
-        json = response.parsed_body
-        expect(json['accounts'].length).to eq(2)
-        expect(json['accounts'][0]).to eq(serialized_account(account))
-        expect(json['accounts'][1]).to eq(serialized_account(deactivated_account))
-      end
+      json = response.parsed_body
+      expect(json['accounts'].length).to eq(2)
+      expect(json['accounts'][0]).to eq(serialized_account(account))
+      expect(json['accounts'][1]).to eq(serialized_account(deleted_account))
     end
   end
 

--- a/spec/javascript/selectors/account-selector.test.js
+++ b/spec/javascript/selectors/account-selector.test.js
@@ -1,5 +1,5 @@
 import { fromJS } from 'immutable';
-import accountSelector from 'selectors/account-selector';
+import accountSelector, { activeAccountSelector} from 'selectors/account-selector';
 
 describe('AccountSelector', () => {
   it('groups accounts in account groups', () => {
@@ -9,7 +9,7 @@ describe('AccountSelector', () => {
 
     const groupedAccounts = accountSelector({
       accountStore: fromJS({
-        accountTypes: [{ id: 1, code: 'savings', name: 'Savings' }, { id: 2, code: 'share', name: 'Share' }],
+        accountTypes: [{ id: 1, code: 'savings', name: 'Savings' }, { id: 2, code: 'share', name: 'Share' }, { id: 3, code: 'loan', name: 'Loan' }],
         accounts: [account1, account2, account3],
       }),
     }).toJS();
@@ -17,6 +17,26 @@ describe('AccountSelector', () => {
     expect(groupedAccounts).toEqual({
       share: [account1],
       savings: [account2, account3],
+    });
+  });
+
+  it('groups only active accounts in account groups', () => {
+    const account1 = { id: 11, name: 'account1', accountType: 'share', deletedAt: null };
+    const account2 = { id: 12, name: 'account2', accountType: 'savings', deletedAt: null };
+    const account3 = { id: 13, name: 'account3', accountType: 'share', deletedAt: '2022-01-01' };
+    const account4 = { id: 14, name: 'account4', accountType: 'savings', deletedAt: null };
+    const account5 = { id: 15, name: 'account5', accountType: 'savings', deletedAt: '2022-01-01' };
+
+    const activeAccounts = activeAccountSelector({
+      accountStore: fromJS({
+        accountTypes: [{ id: 1, code: 'savings', name: 'Savings' }, { id: 2, code: 'share', name: 'Share' }],
+        accounts: [account1, account2, account3, account4, account5],
+      }),
+    }).toJS();
+
+    expect(activeAccounts).toEqual({
+      share: [account1],
+      savings: [account2, account4],
     });
   });
 });

--- a/spec/javascript/transformers/account-transformer.test.js
+++ b/spec/javascript/transformers/account-transformer.test.js
@@ -73,6 +73,7 @@ describe("AccountTransformer", () => {
         starting_balance: 300,
         starting_date: "2015-04-01",
         current_balance: 5000,
+        deleted_at: "2022-01-01",
       };
 
       const transformedAccount = accountTransformer.transformFromApi(account);
@@ -84,6 +85,7 @@ describe("AccountTransformer", () => {
       expect(transformedAccount.openingBalance).toEqual(300);
       expect(transformedAccount.openingBalanceDate).toEqual("2015-04-01");
       expect(transformedAccount.currentBalance).toEqual(5000);
+      expect(transformedAccount.deletedAt).toEqual("2022-01-01");
     });
 
     it("converts loan account from API format", () => {
@@ -97,6 +99,7 @@ describe("AccountTransformer", () => {
         interest_rate: 5.77,
         starting_date: "2015-04-01",
         current_balance: 2000,
+        deleted_at: "2022-01-01",
       };
 
       const transformedAccount = accountTransformer.transformFromApi(account);
@@ -110,6 +113,7 @@ describe("AccountTransformer", () => {
       expect(transformedAccount.interestRate).toEqual(5.77);
       expect(transformedAccount.openingBalanceDate).toEqual("2015-04-01");
       expect(transformedAccount.currentBalance).toEqual(2000);
+      expect(transformedAccount.deletedAt).toEqual("2022-01-01");
     });
 
     it("converts share account from API format", () => {
@@ -119,6 +123,7 @@ describe("AccountTransformer", () => {
         name: "myAccount",
         ticker: "myTicker",
         current_balance: 5000,
+        deleted_at: "2022-01-01",
       };
 
       const transformedAccount = accountTransformer.transformFromApi(account);
@@ -128,6 +133,7 @@ describe("AccountTransformer", () => {
       expect(transformedAccount.name).toEqual("myAccount");
       expect(transformedAccount.ticker).toEqual("myTicker");
       expect(transformedAccount.currentBalance).toEqual(5000);
+      expect(transformedAccount.deletedAt).toEqual("2022-01-01");
     });
 
     it("throws an error for unknown account type", () => {


### PR DESCRIPTION
Since we added the ability to "deactivate" accounts, we've had problems viewing reports, since the api does not return the accounts and the UI does not know what to display for account name and bank.

This PR switches the API back to returning ALL accounts, and the UI will filter out deactivated accounts as appropriate