### PR TITLE
Fix linebreak import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+# Ignore startup scripts
+startup.sh

--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,5 @@ group :test do
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 6.1.2'
 end
+
+gem 'pdf-reader', '~> 2.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     actioncable (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -80,6 +81,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    afm (1.0.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.7)
@@ -112,6 +114,7 @@ GEM
       railties (>= 5.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashery (2.1.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -160,6 +163,12 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     psych (4.0.6)
       stringio
     puma (6.4.2)
@@ -262,6 +271,7 @@ GEM
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     sqlite3 (1.7.3-aarch64-linux)
     sqlite3 (1.7.3-arm-linux)
     sqlite3 (1.7.3-arm64-darwin)
@@ -271,6 +281,8 @@ GEM
     stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -302,6 +314,7 @@ DEPENDENCIES
   database_cleaner-active_record
   debug
   factory_bot_rails
+  pdf-reader (~> 2.15)
   psych (= 4.0.6)
   puma (>= 5.0)
   rails (~> 7.1.3.4)

--- a/app/controllers/api/report_controller.rb
+++ b/app/controllers/api/report_controller.rb
@@ -87,6 +87,11 @@ module Api
       end
     end
 
+    def recurring_payments
+      search = Lib::RecurringPaymentsSearch.new
+      render json: { report: search.report }
+    end
+
     private
 
     def merge_data(income_data, expense_data)

--- a/app/controllers/api/transactions_controller.rb
+++ b/app/controllers/api/transactions_controller.rb
@@ -68,7 +68,11 @@ module Api
 
     def import
       transactions = Lib::TransactionImporter.new(account, params[:data_file]).execute
-      render json: transactions
+      render json: {
+        imported_transactions: transactions.map do |transaction|
+          ImportedTransactionSerializer.new(transaction).serializable_hash
+        end
+      }
     end
 
     def matching

--- a/app/javascript/components/MyMoney.tsx
+++ b/app/javascript/components/MyMoney.tsx
@@ -17,6 +17,7 @@ import IncomeExpenseBarChart from './reports/IncomeExpenseBarChart'
 import IncomeVsExpensesReport from './reports/IncomeVsExpensesReport'
 import LoanReport from './loan/LoanReport'
 import NetBalanceChart from './reports/NetBalanceChart'
+import RecurringPaymentsReport from './reports/RecurringPaymentsReport'
 import store from '../stores/store'
 
 const MyMoney = () => {
@@ -54,6 +55,10 @@ const MyMoney = () => {
             <Route
               path="/reports/subcategoryReport"
               element={<SubcategoryReport />}
+            />
+            <Route
+              path="/reports/recurringPayments"
+              element={<RecurringPaymentsReport />}
             />
             <Route path="/reports/loanReport" element={<LoanReport />} />
           </Routes>

--- a/app/javascript/components/common/criteria/AccountFilter.tsx
+++ b/app/javascript/components/common/criteria/AccountFilter.tsx
@@ -15,16 +15,22 @@ import { RootState } from 'stores/store'
 
 type AccountFilterProps = {
   isMulti: boolean
+  activeOnly?: boolean
 }
 
 const AccountFilter = (props: AccountFilterProps) => {
-  const { isSuccess, groupedAccounts, currentAccount } = useGroupedAccounts()
+  const { isSuccess, groupedAccounts, activeGroupedAccounts, currentAccount } =
+    useGroupedAccounts()
   const currentSelectedAccounts = useSelector(
     (state: RootState) => state.currentStore.currentSelectedAccounts,
   )
   const dispatch = useDispatch()
 
-  const groupedOptions = groupedAccounts?.map((ga) => ({
+  const visibleGroupedAccounts = props.activeOnly
+    ? activeGroupedAccounts
+    : groupedAccounts
+
+  const groupedOptions = visibleGroupedAccounts?.map((ga) => ({
     label: ga.accountType.name,
     options: ga.accounts,
   }))
@@ -41,7 +47,7 @@ const AccountFilter = (props: AccountFilterProps) => {
     }
   }
 
-  if (isSuccess && groupedAccounts && currentAccount) {
+  if (isSuccess && visibleGroupedAccounts && currentAccount) {
     return (
       <div className="account-filter">
         <label htmlFor="accountId" className="control-label">

--- a/app/javascript/components/common/criteria/SearchCriteria.tsx
+++ b/app/javascript/components/common/criteria/SearchCriteria.tsx
@@ -12,6 +12,7 @@ import '../../../stylesheets/search-criteria.scss'
 
 type FilterOptions = {
   multiple?: boolean
+  activeOnly?: boolean
   showSubcategories?: boolean
   allowUnassigned?: boolean
 }
@@ -28,6 +29,7 @@ type SearchCriteriaProps = {
 const SearchCriteria = ({ filters }: SearchCriteriaProps) => {
   const renderFilter = ({ name, options }: Filter) => {
     const allowMultipleAccounts = options?.multiple == true
+    const activeOnly = options?.activeOnly == true
     const showSubcategories = options?.showSubcategories == true
     const allowUnassigned = options?.allowUnassigned == true
 
@@ -36,7 +38,11 @@ const SearchCriteria = ({ filters }: SearchCriteriaProps) => {
         return <DateRangeFilter key={DATE_RANGE_FILTER} />
       case ACCOUNT_FILTER:
         return (
-          <AccountFilter key={ACCOUNT_FILTER} isMulti={allowMultipleAccounts} />
+          <AccountFilter
+            key={ACCOUNT_FILTER}
+            isMulti={allowMultipleAccounts}
+            activeOnly={activeOnly}
+          />
         )
       case CATEGORY_FILTER:
         return (

--- a/app/javascript/components/import/FileChooserModal.tsx
+++ b/app/javascript/components/import/FileChooserModal.tsx
@@ -50,7 +50,7 @@ const FileChooserModal = (props: FileChooserModalProps) => {
         <p>
           Please select a file to import transactions into the &apos;
           <strong>{props.account.name}</strong>
-          &apos; Account. The file must be in OFX format
+          &apos; Account. The file must be in OFX, CSV, or PDF format
         </p>
         <p>Choose File:</p>
         <div className="file-chooser">
@@ -63,7 +63,7 @@ const FileChooserModal = (props: FileChooserModalProps) => {
             name="fileChooser"
             type="file"
             style={{ display: 'none' }}
-            accept=".ofx,.csv"
+            accept="application/pdf,.pdf,text/csv,.csv,.ofx"
             onChange={onChooseFile}
           />
           {renderFileName()}

--- a/app/javascript/components/layout/Header.tsx
+++ b/app/javascript/components/layout/Header.tsx
@@ -38,6 +38,9 @@ const Header = () => (
         <LinkContainer to="/reports/subcategoryReport">
           <NavDropdown.Item>Subcategory Report</NavDropdown.Item>
         </LinkContainer>
+        <LinkContainer to="/reports/recurringPayments">
+          <NavDropdown.Item>Recurring Payments</NavDropdown.Item>
+        </LinkContainer>
         <NavDropdown.Divider />
         <LinkContainer to="/reports/accountBalance">
           <NavDropdown.Item>Account Balance Line Chart</NavDropdown.Item>

--- a/app/javascript/components/reports/RecurringPaymentsReport.tsx
+++ b/app/javascript/components/reports/RecurringPaymentsReport.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import PageHeader from 'components/common/PageHeader'
+import RecurringPaymentsTable from './RecurringPaymentsTable'
+import { useGetRecurringPaymentsReportQuery } from 'stores/reportApi'
+
+import '../../stylesheets/common.scss'
+import '../../stylesheets/report.scss'
+
+const RecurringPaymentsReport = () => {
+  const { data, isLoading } = useGetRecurringPaymentsReportQuery()
+
+  return (
+    <div>
+      <PageHeader title="Recurring Payments Report" isLoading={isLoading} />
+      <div id="report" className="container">
+        <p>
+          Highlights likely subscription-style charges based on the same amount
+          repeated monthly over the last 6 months.
+        </p>
+        <RecurringPaymentsTable candidates={data || []} />
+      </div>
+    </div>
+  )
+}
+
+export default RecurringPaymentsReport

--- a/app/javascript/components/reports/RecurringPaymentsTable.tsx
+++ b/app/javascript/components/reports/RecurringPaymentsTable.tsx
@@ -1,0 +1,124 @@
+import React, { Fragment, useState } from 'react'
+import moment from 'moment'
+
+import Amount from 'components/common/Amount'
+import { RecurringPaymentCandidate } from 'types/models'
+
+type RecurringPaymentsTableProps = {
+  candidates: RecurringPaymentCandidate[]
+}
+
+const recurringDescription = (merchant: string) => {
+  if (merchant.length > 0) return merchant
+  return 'Unlabelled merchant'
+}
+
+const transactionDescription = (
+  memo: string | undefined,
+  notes: string | undefined,
+) => {
+  const description = memo || notes || 'No description'
+  return description.length > 0 ? description : 'No description'
+}
+
+const RecurringPaymentsTable = ({
+  candidates,
+}: RecurringPaymentsTableProps) => {
+  const [expandedRows, setExpandedRows] = useState<{ [rowKey: string]: boolean }>(
+    {},
+  )
+
+  const toggleRow = (rowKey: string) => {
+    setExpandedRows((existingRows) => ({
+      ...existingRows,
+      [rowKey]: !existingRows[rowKey],
+    }))
+  }
+
+  if (candidates.length === 0) {
+    return (
+      <div className="empty-state">
+        No recurring monthly payments were detected in the last 6 months.
+      </div>
+    )
+  }
+
+  const sortedCandidates = [...candidates].sort((a, b) => {
+    const merchantA = recurringDescription(a.merchant).toLowerCase()
+    const merchantB = recurringDescription(b.merchant).toLowerCase()
+    return merchantA.localeCompare(merchantB)
+  })
+
+  return (
+    <table className="table table-hover table-report" id="recurring-payments">
+      <thead>
+        <tr>
+          <th>Merchant</th>
+          <th className="currency">Amount</th>
+          <th>Months matched</th>
+          <th>Charges</th>
+          <th>Last charge</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {sortedCandidates.map((candidate) => {
+          const rowKey = `${candidate.merchantKey}-${candidate.amount}-${candidate.lastDate}`
+          const isExpanded = expandedRows[rowKey] == true
+
+          return (
+            <Fragment key={rowKey}>
+              <tr>
+                <td>{recurringDescription(candidate.merchant)}</td>
+                <td className="currency">
+                  <Amount amount={candidate.amount} />
+                </td>
+                <td>{candidate.monthsMatched}</td>
+                <td>{candidate.occurrenceCount}</td>
+                <td>{moment(candidate.lastDate, 'YYYY-MM-DD').format('DD-MMM-YYYY')}</td>
+                <td>
+                  <span
+                    className="click-me"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => toggleRow(rowKey)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        toggleRow(rowKey)
+                      }
+                    }}
+                    aria-expanded={isExpanded}
+                    aria-controls={`recurring-transactions-${rowKey}`}
+                  >
+                    <i
+                      className={`fa-solid ${isExpanded ? 'fa-chevron-up' : 'fa-chevron-down'} pr-1`}
+                    ></i>
+                    {isExpanded ? 'Hide details' : 'Show details'}
+                  </span>
+                </td>
+              </tr>
+              {isExpanded ? (
+                <tr id={`recurring-transactions-${rowKey}`}>
+                  <td colSpan={6}>
+                    <ul>
+                      {candidate.transactions.map((transaction) => (
+                        <li key={transaction.id}>
+                          {moment(transaction.date, 'YYYY-MM-DD').format('DD-MMM-YYYY')} |{' '}
+                          {transactionDescription(transaction.memo, transaction.notes)}
+                          {' | '}acct #{transaction.accountId}
+                        </li>
+                      ))}
+                    </ul>
+                  </td>
+                </tr>
+              ) : null}
+            </Fragment>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
+export default RecurringPaymentsTable

--- a/app/javascript/components/transactions/SearchCriteria.tsx
+++ b/app/javascript/components/transactions/SearchCriteria.tsx
@@ -68,7 +68,7 @@ const SearchCriteria = () => {
     <React.Fragment>
       <CommonSearchCriteria
         filters={[
-          { name: ACCOUNT_FILTER, options: { multiple: false } },
+          { name: ACCOUNT_FILTER, options: { multiple: false, activeOnly: true } },
           { name: DATE_RANGE_FILTER },
         ]}
       />

--- a/app/javascript/stores/applicationApi.ts
+++ b/app/javascript/stores/applicationApi.ts
@@ -15,10 +15,11 @@ export const applicationApi = createApi({
     'loan-report',
     'matching-transactions',
     'net-balance-report',
+    'recurring-payments-report',
     'subcategories',
     'subcategory-report',
     'transactions',
   ],
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:3000/api' }),
+  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
   endpoints: () => ({}),
 })

--- a/app/javascript/stores/reportApi.ts
+++ b/app/javascript/stores/reportApi.ts
@@ -7,12 +7,14 @@ import {
   LineSeriesData,
   LoanReportResponse,
   PointResponse,
+  RecurringPaymentCandidate,
   TransactionReport,
 } from 'types/models'
 import {
   TransactionReportResponse,
   IncomeExpenseReportResponse,
   AccountBalanceReportResponse,
+  RecurringPaymentsReportResponse,
 } from 'types/api'
 import {
   chartDataForCombo,
@@ -132,6 +134,28 @@ export const reportApi = applicationApi.injectEndpoints({
         response.report,
       providesTags: () => ['net-balance-report'],
     }),
+    getRecurringPaymentsReport: builder.query<RecurringPaymentCandidate[], void>({
+      query() {
+        return {
+          url: 'report/recurring_payments',
+        }
+      },
+      transformResponse: (response: RecurringPaymentsReportResponse) =>
+        response.report.map((candidate) => ({
+          merchant: candidate.merchant,
+          merchantKey: candidate.merchant_key,
+          amount: candidate.amount,
+          monthsMatched: candidate.months_matched,
+          occurrenceCount: candidate.occurrence_count,
+          firstDate: candidate.first_date,
+          lastDate: candidate.last_date,
+          monthlyOccurrences: candidate.monthly_occurrences,
+          transactions: candidate.transactions.map((transaction) =>
+            transformFromApi(transaction),
+          ),
+        })),
+      providesTags: () => ['recurring-payments-report'],
+    }),
   }),
 })
 
@@ -143,4 +167,5 @@ export const {
   useGetSubcategoryReportQuery,
   useGetAccountBalanceReportQuery,
   useGetNetBalanceReportQuery,
+  useGetRecurringPaymentsReportQuery,
 } = reportApi

--- a/app/javascript/types/api.ts
+++ b/app/javascript/types/api.ts
@@ -171,3 +171,19 @@ export type AccountBalanceReportResponse = {
   account_id: number
   report: MonthTotals[]
 }
+
+export type RecurringPaymentCandidateResponse = {
+  merchant: string
+  merchant_key: string
+  amount: number
+  months_matched: number
+  occurrence_count: number
+  first_date: string
+  last_date: string
+  monthly_occurrences: { [month: string]: number }
+  transactions: TransactionResponse[]
+}
+
+export type RecurringPaymentsReportResponse = {
+  report: RecurringPaymentCandidateResponse[]
+}

--- a/app/javascript/types/models.ts
+++ b/app/javascript/types/models.ts
@@ -228,3 +228,15 @@ export type BarChartData = {
 export type AccountBalanceReport = {
   [accountId: string]: Point[]
 }
+
+export type RecurringPaymentCandidate = {
+  merchant: string
+  merchantKey: string
+  amount: number
+  monthsMatched: number
+  occurrenceCount: number
+  firstDate: string
+  lastDate: string
+  monthlyOccurrences: { [month: string]: number }
+  transactions: Transaction[]
+}

--- a/app/models/lib/csv_parser.rb
+++ b/app/models/lib/csv_parser.rb
@@ -16,17 +16,22 @@ module Lib
     private
 
     def parse
-      txn_array = []
+      @file.rewind if @file.respond_to?(:rewind)
+      csv = CSV.parse(@file.read, headers: true, header_converters: :symbol)
+      return [] if csv.empty?
 
-      CSV.parse(@file.read, headers: true, header_converters: :symbol) do |row|
-        transaction = ImportedTransaction.new
-        transaction.date = parse_date row[:date]
-        transaction.memo = row[:description]
-        transaction.amount = parse_debit(row[:debit]) || parse_credit(row[:credit])
-        txn_array << transaction
-      end
+      adapter_for(csv.headers).new(csv).transactions
+    end
 
-      txn_array
+    def adapter_for(headers)
+      adapters.find { |adapter_class| adapter_class.matches_headers?(headers) } || Lib::LegacyCsvTransactionAdapter
+    end
+
+    def adapters
+      [
+        Lib::PeopleFirstBankCsvAdapter,
+        Lib::LegacyCsvTransactionAdapter
+      ]
     end
   end
 end

--- a/app/models/lib/csv_parser.rb
+++ b/app/models/lib/csv_parser.rb
@@ -4,6 +4,8 @@ require 'csv'
 
 module Lib
   class CsvParser < Lib::Parser
+    PENDING_PURCHASE_MARKER = 'PURCHASE AUTHORISATION'
+
     def initialize(file)
       super()
       @file = file
@@ -20,7 +22,13 @@ module Lib
       csv = CSV.parse(@file.read, headers: true, header_converters: :symbol)
       return [] if csv.empty?
 
-      adapter_for(csv.headers).new(csv).transactions
+      filtered_rows = csv.reject { |row| pending_purchase_authorisation?(row) }
+
+      adapter_for(csv.headers).new(filtered_rows).transactions
+    end
+
+    def pending_purchase_authorisation?(row)
+      row.fields.any? { |value| value.to_s.upcase.include?(PENDING_PURCHASE_MARKER) }
     end
 
     def adapter_for(headers)

--- a/app/models/lib/csv_transaction_adapter.rb
+++ b/app/models/lib/csv_transaction_adapter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Lib
+  class CsvTransactionAdapter < Lib::Parser
+    def initialize(rows)
+      super()
+      @rows = rows
+    end
+
+    def transactions
+      @rows.each_with_object([]) do |row, list|
+        transaction = build_transaction(row)
+        list << transaction if transaction
+      end
+    end
+
+    def self.matches_headers?(_headers)
+      raise NotImplementedError
+    end
+
+    private
+
+    def build_transaction(row)
+      date = transaction_date(row)
+      memo = transaction_memo(row)
+      amount = transaction_amount(row)
+
+      return nil if date.nil? || memo.blank? || amount.nil?
+
+      transaction = ImportedTransaction.new
+      transaction.date = date
+      transaction.memo = memo
+      transaction.amount = amount
+      transaction
+    end
+
+    def transaction_date(_row)
+      raise NotImplementedError
+    end
+
+    def transaction_memo(_row)
+      raise NotImplementedError
+    end
+
+    def transaction_amount(_row)
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/models/lib/date_range.rb
+++ b/app/models/lib/date_range.rb
@@ -120,4 +120,15 @@ module Lib
       @from_date = Date.new(Time.zone.today.year - 1, Time.zone.today.month, 1)
     end
   end
+
+  # Last6MonthsDateRange
+  # sets from and to dates to represent the last 6 months (including current month)
+  class Last6MonthsDateRange < DateRange
+    def initialize(_args = {})
+      super()
+      @to_date = Date.new(Time.zone.today.year, Time.zone.today.month, - 1)
+      current_month = Date.new(Time.zone.today.year, Time.zone.today.month, 1)
+      @from_date = current_month << 5
+    end
+  end
 end

--- a/app/models/lib/legacy_csv_transaction_adapter.rb
+++ b/app/models/lib/legacy_csv_transaction_adapter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Lib
+  class LegacyCsvTransactionAdapter < Lib::CsvTransactionAdapter
+    def self.matches_headers?(headers)
+      symbols = headers.compact.map(&:to_sym)
+      symbols.include?(:date) &&
+        symbols.include?(:description) &&
+        (symbols.include?(:debit) || symbols.include?(:credit))
+    end
+
+    private
+
+    def transaction_date(row)
+      parse_date(row[:date])
+    rescue Date::Error, TypeError
+      nil
+    end
+
+    def transaction_memo(row)
+      row[:description].to_s.strip
+    end
+
+    def transaction_amount(row)
+      parse_debit(row[:debit]) || parse_credit(row[:credit])
+    end
+  end
+end

--- a/app/models/lib/pdf_parser.rb
+++ b/app/models/lib/pdf_parser.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'pdf/reader'
+
+module Lib
+  class PdfParser < Lib::Parser
+    def initialize(file)
+      super()
+      @file = file
+    end
+
+    def transactions
+      @transactions ||= parse
+    end
+
+    private
+
+    def parse
+      text = extract_text
+      return [] if text.blank?
+
+      adapter = adapter_for(text)
+      return [] unless adapter
+
+      adapter.transactions
+    end
+
+    def extract_text
+      source = pdf_source
+      source.rewind if source.respond_to?(:rewind)
+      PDF::Reader.new(source).pages.map(&:text).join("\n")
+    end
+
+    def pdf_source
+      return @file.tempfile if @file.respond_to?(:tempfile) && @file.tempfile
+      return @file.path if @file.respond_to?(:path) && @file.path
+
+      @file
+    end
+
+    def adapter_for(text)
+      adapters.find { |adapter_class| adapter_class.matches?(text) }&.new(text)
+    end
+
+    def adapters
+      [Lib::PeopleFirstBankPdfAdapter]
+    end
+  end
+end

--- a/app/models/lib/pdf_transaction_adapter.rb
+++ b/app/models/lib/pdf_transaction_adapter.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module Lib
+  class PdfTransactionAdapter < Lib::Parser
+    AMOUNT_REGEX = /([+-])\s*\$\s*([\d,]+\.\d{2})/
+    DATE_HEADING_REGEX = /\A(\d{1,2})\s*([A-Za-z]{3,9})\s*(\d{4})\z/
+    DATE_SLASH_REGEX = %r{(\d{1,2})\/(\d{1,2})\/(\d{4})}
+
+    def initialize(text)
+      super()
+      @text = text
+    end
+
+    def transactions
+      statement_date = parse_slash_date(@text)
+
+      transaction_text = transaction_section(@text)
+      return [] if transaction_text.blank?
+
+      lines = normalize_lines(transaction_text)
+      build_transactions(lines, statement_date)
+    end
+
+    private
+
+    def transaction_section(_text)
+      raise NotImplementedError
+    end
+
+    def noise_line?(_line)
+      raise NotImplementedError
+    end
+
+    def normalize_lines(text)
+      text
+        .split(/\r\n|\r|\n/)
+        .map { |line| line.encode('UTF-8', invalid: :replace, undef: :replace, replace: ' ') }
+        .map { |line| line.gsub(/[^\x20-\x7E]/, ' ') }
+        .map { |line| line.gsub(/\s+/, ' ').strip }
+        .reject(&:empty?)
+    end
+
+    def build_transactions(lines, statement_date = nil)
+      transactions = []
+      details = []
+      current_date = nil
+
+      lines.each do |line|
+        statement_date ||= parse_slash_date(line)
+
+        if line.casecmp('today').zero?
+          append_trailing_details!(transactions, current_date, details)
+          current_date = statement_date || Time.zone.today
+          details = []
+          next
+        end
+
+        if line.casecmp('yesterday').zero?
+          append_trailing_details!(transactions, current_date, details)
+          base = statement_date || Time.zone.today
+          current_date = base - 1
+          details = []
+          next
+        end
+
+        parsed_date = parse_heading_date(line)
+        if parsed_date
+          append_trailing_details!(transactions, current_date, details)
+          current_date = parsed_date
+          details = []
+          next
+        end
+
+        amount = extract_amount(line)
+        if amount
+          inline_memo = memo_without_amount(line)
+          memo_parts = details.dup
+          memo_parts << inline_memo unless inline_memo.empty? || reference_line?(inline_memo)
+          memo = memo_parts.join(' ').strip
+          details = []
+
+          next if memo.empty? || current_date.nil?
+
+          transaction = ImportedTransaction.new
+          transaction.date = current_date
+          transaction.memo = memo
+          transaction.amount = amount
+          transactions << transaction
+          next
+        end
+
+        next if noise_line?(line)
+
+        details << line
+      end
+
+      transactions
+    end
+
+    def append_trailing_details!(transactions, current_date, details)
+      return if details.empty? || transactions.empty? || current_date.nil?
+      return unless transactions.last.date == current_date
+
+      suffix = details.join(' ').strip
+      return if suffix.empty?
+
+      transactions.last.memo = [transactions.last.memo, suffix].join(' ').strip
+      details.clear
+    end
+
+    def parse_heading_date(line)
+      match = line.match(DATE_HEADING_REGEX)
+      return nil unless match
+
+      parse_date("#{match[1]} #{match[2]} #{match[3]}")
+    rescue Date::Error
+      nil
+    end
+
+    def parse_slash_date(line)
+      match = line.match(DATE_SLASH_REGEX)
+      return nil unless match
+
+      Date.new(match[3].to_i, match[2].to_i, match[1].to_i)
+    rescue Date::Error
+      nil
+    end
+
+    def extract_amount(line)
+      match = line.match(AMOUNT_REGEX)
+      return nil unless match
+
+      parse_amount("#{match[1]}#{match[2]}")
+    end
+
+    def memo_without_amount(line)
+      line.gsub(AMOUNT_REGEX, '').gsub(/\s+/, ' ').strip
+    end
+
+    def reference_line?(line)
+      line.match?(/\A[\d\s\.]+\z/)
+    end
+  end
+end

--- a/app/models/lib/pdf_transaction_adapter.rb
+++ b/app/models/lib/pdf_transaction_adapter.rb
@@ -94,6 +94,7 @@ module Lib
         details << line
       end
 
+      append_trailing_details!(transactions, current_date, details)
       transactions
     end
 

--- a/app/models/lib/people_first_bank_csv_adapter.rb
+++ b/app/models/lib/people_first_bank_csv_adapter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Lib
+  class PeopleFirstBankCsvAdapter < Lib::CsvTransactionAdapter
+    def self.matches_headers?(headers)
+      symbols = headers.compact.map(&:to_sym)
+      symbols.include?(:date) &&
+        symbols.include?(:amount) &&
+        symbols.include?(:transaction_details)
+    end
+
+    private
+
+    def transaction_date(row)
+      parse_date(row[:date])
+    rescue Date::Error, TypeError
+      nil
+    end
+
+    def transaction_memo(row)
+      [
+        row[:transaction_details],
+        row[:merchant_name],
+        row[:transaction_type]
+      ].map { |value| value.to_s.strip }.find(&:present?).to_s
+    end
+
+    def transaction_amount(row)
+      value = row[:amount].to_s.strip
+      return nil if value.empty?
+
+      parse_amount(value)
+    end
+  end
+end

--- a/app/models/lib/people_first_bank_pdf_adapter.rb
+++ b/app/models/lib/people_first_bank_pdf_adapter.rb
@@ -16,10 +16,8 @@ module Lib
       start_match = text.match(START_MARKER_REGEX)
       return nil unless start_match
 
-      end_match = text.match(END_MARKER_REGEX)
+      end_match = text.match(END_MARKER_REGEX, start_match.end(0))
       return nil unless end_match
-
-      return nil if end_match.begin(0) <= start_match.end(0)
 
       text[start_match.end(0)...end_match.begin(0)]
     end

--- a/app/models/lib/people_first_bank_pdf_adapter.rb
+++ b/app/models/lib/people_first_bank_pdf_adapter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Lib
+  class PeopleFirstBankPdfAdapter < Lib::PdfTransactionAdapter
+    START_MARKER_REGEX = /\b\d+\s+result(?:s)?\s+found\b/i
+    END_MARKER_REGEX = /all\s+transactions\s+have\s+been\s+loaded/i
+
+    def self.matches?(text)
+      normalized = text.to_s.downcase
+      normalized.include?('retail banking') || normalized.match?(/people.*bank/)
+    end
+
+    private
+
+    def transaction_section(text)
+      start_match = text.match(START_MARKER_REGEX)
+      return nil unless start_match
+
+      end_match = text.match(END_MARKER_REGEX)
+      return nil unless end_match
+
+      return nil if end_match.begin(0) <= start_match.end(0)
+
+      text[start_match.end(0)...end_match.begin(0)]
+    end
+
+    def noise_line?(line)
+      line.match?(%r{\Ahttps?://}i) ||
+        line.match?(/\A\d{1,2}\/\d{1,2}\/\d{4},\s*\d{1,2}:\d{2}\s+accounts\s+-\s+retail\s+banking\z/i) ||
+        line.match?(/\Aaccounts\s+-\s+retail\s+banking\z/i) ||
+        line.match?(/\A(backto\s+accounts|transactions|account\s+details|quick\s+actions|quick\s+links)\z/i) ||
+        line.match?(/\A(apply|close|clear\s*filters|search|filters)\z/i)
+    end
+  end
+end

--- a/app/models/lib/recurring_payments_search.rb
+++ b/app/models/lib/recurring_payments_search.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Lib
+  class RecurringPaymentsSearch < Search
+    MINIMUM_MONTHS = 3
+
+    def initialize(attrs = {})
+      super()
+      @date_range = attrs.fetch(:date_range, Lib::Last6MonthsDateRange.new)
+    end
+
+    def report
+      grouped_candidates
+        .select { |candidate| candidate[:months_matched] >= MINIMUM_MONTHS }
+        .sort_by { |candidate| [-candidate[:months_matched], -candidate[:amount].abs, candidate[:merchant]] }
+    end
+
+    private
+
+    def transaction_query
+      Transaction
+        .for_banking_accounts
+        .search_by_date(@date_range)
+        .where(matching_transaction: nil)
+        .where('amount < 0')
+        .reverse_date_order
+    end
+
+    def grouped_candidates
+      groups = transactions.group_by do |transaction|
+        [normalized_merchant(transaction), transaction.amount]
+      end
+
+      groups.map do |(merchant_key, amount), grouped_transactions|
+        month_counts = grouped_transactions.each_with_object(Hash.new(0)) do |transaction, counts|
+          counts[transaction.date.strftime('%Y-%m')] += 1
+        end
+
+        {
+          merchant: display_merchant(grouped_transactions),
+          merchant_key: merchant_key,
+          amount: amount,
+          months_matched: month_counts.keys.length,
+          occurrence_count: grouped_transactions.length,
+          first_date: grouped_transactions.min_by(&:date).date.to_s,
+          last_date: grouped_transactions.max_by(&:date).date.to_s,
+          monthly_occurrences: month_counts.sort.to_h,
+          transactions: grouped_transactions
+        }
+      end
+    end
+
+    def normalized_merchant(transaction)
+      merchant_text(transaction)
+        .downcase
+        .gsub(/[^a-z0-9\s]/, ' ')
+        .gsub(/\s+/, ' ')
+        .strip
+    end
+
+    def display_merchant(grouped_transactions)
+      merchant_counts = grouped_transactions.each_with_object(Hash.new(0)) do |transaction, counts|
+        merchant = merchant_text(transaction).strip
+        counts[merchant] += 1
+      end
+
+      merchant_counts.max_by { |merchant, count| [count, merchant.length] }&.first || ''
+    end
+
+    def merchant_text(transaction)
+      return transaction.memo.to_s if transaction.memo.present?
+      return transaction.notes.to_s if transaction.notes.present?
+
+      ''
+    end
+  end
+end

--- a/app/models/lib/transaction_importer.rb
+++ b/app/models/lib/transaction_importer.rb
@@ -18,7 +18,14 @@ module Lib
     end
 
     def parser
-      @data_file.original_filename.end_with?('ofx') ? Lib::OfxParser.new(@data_file) : Lib::CsvParser.new(@data_file)
+      case File.extname(@data_file.original_filename).downcase
+      when '.ofx'
+        Lib::OfxParser.new(@data_file)
+      when '.pdf'
+        Lib::PdfParser.new(@data_file)
+      else
+        Lib::CsvParser.new(@data_file)
+      end
     end
 
     def build_transaction(txn)

--- a/app/models/lib/transaction_importer.rb
+++ b/app/models/lib/transaction_importer.rb
@@ -2,6 +2,10 @@
 
 module Lib
   class TransactionImporter
+    NON_PRINTING_REGEX = /[\u200B-\u200D\uFEFF]/.freeze
+    MEMO_TOKEN_REGEX = /\A[[:alnum:]\-.]+\z/.freeze
+    NAME_SUFFIX_TOKEN_REGEX = /\A[[:alpha:]'\-]+\z/.freeze
+
     def initialize(account, data_file)
       @account = account
       @data_file = data_file
@@ -30,7 +34,7 @@ module Lib
 
     def build_transaction(txn)
       txn.account = @account
-      txn.duplicate = Transaction.exists?(account: @account, date: txn.date, memo: txn.memo, amount: txn.amount)
+      txn.duplicate = duplicate_transaction?(txn)
       txn.import = !txn.duplicate
       apply_patterns(txn)
     end
@@ -38,9 +42,12 @@ module Lib
     def apply_patterns(transaction)
       return if transaction.memo.blank?
 
-      # Pattern.where(account_id: @account.id).find_each do |pattern|
-      Pattern.find_each do |pattern|
-        next unless transaction.memo.downcase.include? pattern.match_text.downcase
+      normalized_memo = normalize_memo(transaction.memo)
+
+      Pattern.where(account_id: @account.id).find_each do |pattern|
+        normalized_match_text = normalize_memo(pattern.match_text)
+        next if normalized_match_text.blank?
+        next unless normalized_memo.include?(normalized_match_text)
 
         allocate_transaction(transaction, pattern)
         break
@@ -51,6 +58,57 @@ module Lib
       transaction.category_id = pattern.category_id
       transaction.subcategory_id = pattern.subcategory_id
       transaction.notes = pattern.notes
+    end
+
+    def duplicate_transaction?(txn)
+      exact_scope = Transaction.where(account: @account, date: txn.date, amount: txn.amount)
+      return exact_scope.exists?(memo: nil) if txn.memo.nil?
+
+      normalized_memo = normalize_memo(txn.memo)
+      exact_scope.where.not(memo: nil).any? do |existing|
+        memo_equivalent_for_duplicate?(normalize_memo(existing.memo), normalized_memo)
+      end
+    end
+
+    def memo_equivalent_for_duplicate?(left_memo, right_memo)
+      return true if left_memo == right_memo
+
+      short_memo, long_memo = [left_memo, right_memo].sort_by(&:length)
+      return false unless long_memo.start_with?(short_memo)
+
+      suffix = long_memo[short_memo.length..]&.strip
+      reference_suffix?(suffix) || short_name_suffix?(suffix)
+    end
+
+    def reference_suffix?(suffix)
+      return false if suffix.blank?
+
+      tokens = suffix.split
+      return false if tokens.empty?
+      return false unless tokens.all? { |token| token.match?(MEMO_TOKEN_REGEX) && token.match?(/\d/) }
+
+      suffix.count('0-9') >= 4
+    end
+
+    def short_name_suffix?(suffix)
+      return false if suffix.blank?
+
+      tokens = suffix.split
+      return false if tokens.empty? || tokens.length > 2
+      return false unless tokens.all? { |token| token.match?(NAME_SUFFIX_TOKEN_REGEX) }
+
+      suffix.length <= 24
+    end
+
+    def normalize_memo(value)
+      value.to_s
+        .encode('UTF-8', invalid: :replace, undef: :replace, replace: ' ')
+        .unicode_normalize(:nfkc)
+        .gsub(/\r\n|\r|\n/, ' ')
+        .gsub(NON_PRINTING_REGEX, '')
+        .gsub(/\s+/, ' ')
+        .strip
+        .downcase
     end
   end
 end

--- a/app/models/lib/transaction_importer.rb
+++ b/app/models/lib/transaction_importer.rb
@@ -36,6 +36,8 @@ module Lib
     end
 
     def apply_patterns(transaction)
+      return if transaction.memo.blank?
+
       # Pattern.where(account_id: @account.id).find_each do |pattern|
       Pattern.find_each do |pattern|
         next unless transaction.memo.downcase.include? pattern.match_text.downcase

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     get 'report/eod_balance'
     get 'report/net_balance'
     get 'report/home_loan'
+    get 'report/recurring_payments'
     get 'report/index'
   end
 

--- a/spec/controllers/api/report_controller_spec.rb
+++ b/spec/controllers/api/report_controller_spec.rb
@@ -241,4 +241,51 @@ RSpec.describe Api::ReportController do
       expect(json['message']).to eq('Account is not a loan account')
     end
   end
+
+  describe 'recurring payments report' do
+    it 'returns recurring payment candidates' do
+      report_data = [
+        {
+          merchant: 'NETFLIX.COM',
+          merchant_key: 'netflix com',
+          amount: -1599,
+          months_matched: 4,
+          occurrence_count: 4,
+          first_date: '2026-01-10',
+          last_date: '2026-04-10',
+          monthly_occurrences: { '2026-01' => 1, '2026-02' => 1, '2026-03' => 1, '2026-04' => 1 },
+          transactions: []
+        }
+      ]
+
+      search = instance_double Lib::RecurringPaymentsSearch
+      allow(Lib::RecurringPaymentsSearch).to receive(:new).and_return(search)
+      allow(search).to receive(:report).and_return(report_data)
+
+      get :recurring_payments
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['report']).to eq(
+        [
+          {
+            'merchant' => 'NETFLIX.COM',
+            'merchant_key' => 'netflix com',
+            'amount' => -1599,
+            'months_matched' => 4,
+            'occurrence_count' => 4,
+            'first_date' => '2026-01-10',
+            'last_date' => '2026-04-10',
+            'monthly_occurrences' => {
+              '2026-01' => 1,
+              '2026-02' => 1,
+              '2026-03' => 1,
+              '2026-04' => 1
+            },
+            'transactions' => []
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/controllers/api/transactions_controller_spec.rb
+++ b/spec/controllers/api/transactions_controller_spec.rb
@@ -3,6 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe Api::TransactionsController do
+  describe 'POST import' do
+    it 'renders an empty imported transaction collection without error' do
+      account = instance_double(Account)
+      importer = instance_double(Lib::TransactionImporter)
+
+      allow(controller).to receive(:account).and_return(account)
+      allow(Lib::TransactionImporter).to receive(:new).with(account, 'uploaded-file').and_return(importer)
+      allow(importer).to receive(:execute).and_return([])
+
+      post :import, params: { account_id: 1, data_file: 'uploaded-file' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq({ 'imported_transactions' => [] })
+    end
+  end
+
   describe 'GET index' do
     it 'returns all transactions for specified account for specified date' do
       t1 = FactoryBot.create(:transaction, date: '2014-07-03')
@@ -223,17 +239,18 @@ RSpec.describe Api::TransactionsController do
       account = FactoryBot.create(:account)
       file = 'data_file'
       importer = instance_double(Lib::TransactionImporter)
+      transaction = ImportedTransaction.new(date: '2014-07-01', amount: 100, memo: 'transaction')
 
       allow(Lib::TransactionImporter).to receive(:new).with(account, file).and_return(importer)
-      allow(importer).to receive(:execute).and_return(transactions: ['transaction'])
+      allow(importer).to receive(:execute).and_return([transaction])
 
-      get :import, params: { account_id: account.id, data_file: file }
+      post :import, params: { account_id: account.id, data_file: file }
 
       expect(response).to have_http_status(:ok)
 
       json = response.parsed_body
-      expect(json['transactions'].length).to eq(1)
-      expect(json['transactions'][0]).to eq('transaction')
+      expect(json['imported_transactions'].length).to eq(1)
+      expect(json['imported_transactions'][0]['memo']).to eq('transaction')
     end
   end
 

--- a/spec/fixtures/test_people_first.csv
+++ b/spec/fixtures/test_people_first.csv
@@ -1,0 +1,3 @@
+Date,Amount,Account Number,,Transaction Type,Transaction Details,Balance,Category,Merchant Name,Processed On
+11/06/2026,-16.00,123456,,Card Payment,Coffee Shop,-100.00,Food,Coffee Club,11/06/2026
+10/06/2026,3820.00,123456,,Direct Credit,,3720.00,Income,,10/06/2026

--- a/spec/javascript/components/reports/RecurringPaymentsReport.test.tsx
+++ b/spec/javascript/components/reports/RecurringPaymentsReport.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import store from 'stores/store'
+import RecurringPaymentsReport from 'components/reports/RecurringPaymentsReport'
+import { useGetRecurringPaymentsReportQuery } from 'stores/reportApi'
+
+vi.mock('stores/reportApi', () => ({
+  useGetRecurringPaymentsReportQuery: vi.fn(),
+}))
+
+const useRecurringPaymentsQuery = vi.mocked(useGetRecurringPaymentsReportQuery)
+
+describe('RecurringPaymentsReport', () => {
+  beforeEach(() => {
+    useRecurringPaymentsQuery.mockReturnValue({
+      data: [
+        {
+          merchant: 'Spotify',
+          merchantKey: 'spotify',
+          amount: -1299,
+          monthsMatched: 3,
+          occurrenceCount: 3,
+          firstDate: '2026-02-02',
+          lastDate: '2026-04-02',
+          monthlyOccurrences: {
+            '2026-02': 1,
+            '2026-03': 1,
+            '2026-04': 1,
+          },
+          transactions: [
+            {
+              id: 1,
+              accountId: 1,
+              date: '2026-04-02',
+              memo: 'Spotify',
+              notes: '',
+              amount: -1299,
+            },
+          ],
+        },
+      ],
+      isLoading: false,
+    } as any)
+  })
+
+  test('renders recurring payment rows from API data', async () => {
+    render(
+      <Provider store={store}>
+        <RecurringPaymentsReport />
+      </Provider>,
+    )
+
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toEqual(
+      'Recurring Payments Report',
+    )
+
+    expect(screen.getByText('Spotify')).toBeDefined()
+    expect(screen.getByText('02-Apr-2026')).toBeDefined()
+  })
+
+  test('renders empty state when no recurring payments are returned', async () => {
+    useRecurringPaymentsQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as any)
+
+    render(
+      <Provider store={store}>
+        <RecurringPaymentsReport />
+      </Provider>,
+    )
+
+    expect(
+      screen.getByText(
+        'No recurring monthly payments were detected in the last 6 months.',
+      ),
+    ).toBeDefined()
+  })
+})

--- a/spec/javascript/components/reports/RecurringPaymentsTable.test.tsx
+++ b/spec/javascript/components/reports/RecurringPaymentsTable.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import RecurringPaymentsTable from 'components/reports/RecurringPaymentsTable'
+import { RecurringPaymentCandidate } from 'types/models'
+
+const candidates: RecurringPaymentCandidate[] = [
+  {
+    merchant: 'NETFLIX.COM',
+    merchantKey: 'netflix com',
+    amount: -1599,
+    monthsMatched: 4,
+    occurrenceCount: 4,
+    firstDate: '2026-01-10',
+    lastDate: '2026-04-10',
+    monthlyOccurrences: {
+      '2026-01': 1,
+      '2026-02': 1,
+      '2026-03': 1,
+      '2026-04': 1,
+    },
+    transactions: [
+      {
+        id: 1,
+        accountId: 2,
+        date: '2026-04-10',
+        memo: 'NETFLIX.COM',
+        notes: '',
+        amount: -1599,
+      },
+      {
+        id: 2,
+        accountId: 2,
+        date: '2026-03-10',
+        memo: 'NETFLIX.COM',
+        notes: '',
+        amount: -1599,
+      },
+    ],
+  },
+  {
+    merchant: 'APPLE.COM',
+    merchantKey: 'apple com',
+    amount: -499,
+    monthsMatched: 3,
+    occurrenceCount: 3,
+    firstDate: '2026-02-01',
+    lastDate: '2026-04-01',
+    monthlyOccurrences: {
+      '2026-02': 1,
+      '2026-03': 1,
+      '2026-04': 1,
+    },
+    transactions: [
+      {
+        id: 3,
+        accountId: 2,
+        date: '2026-04-01',
+        memo: 'APPLE.COM',
+        notes: '',
+        amount: -499,
+      },
+    ],
+  },
+]
+
+describe('RecurringPaymentsTable', () => {
+  test('renders recurring payment candidates and expands details on click', () => {
+    const { container } = render(<RecurringPaymentsTable candidates={candidates} />)
+
+    expect(screen.getByText('NETFLIX.COM')).toBeDefined()
+    expect(screen.getByText('APPLE.COM')).toBeDefined()
+    expect(screen.getByText('10-Apr-2026')).toBeDefined()
+
+    expect(screen.queryByText(/acct #2/)).toBeNull()
+
+    const netflixToggle = container.querySelector(
+      '[aria-controls="recurring-transactions-netflix com--1599-2026-04-10"]',
+    )
+    expect(netflixToggle).toBeDefined()
+    fireEvent.click(netflixToggle as Element)
+
+    expect(screen.getAllByText(/acct #2/).length).toBe(2)
+    expect(netflixToggle?.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(netflixToggle as Element)
+    expect(screen.queryByText(/acct #2/)).toBeNull()
+  })
+
+  test('orders rows alphabetically by merchant', () => {
+    const { container } = render(<RecurringPaymentsTable candidates={candidates} />)
+
+    const merchantCells = Array.from(
+      container.querySelectorAll('#recurring-payments tbody tr td:first-child'),
+    ).map((cell) => cell.textContent)
+
+    expect(merchantCells[0]).toBe('APPLE.COM')
+    expect(merchantCells[1]).toBe('NETFLIX.COM')
+  })
+
+  test('renders an empty state when there are no candidates', () => {
+    render(<RecurringPaymentsTable candidates={[]} />)
+
+    expect(
+      screen.getByText(
+        'No recurring monthly payments were detected in the last 6 months.',
+      ),
+    ).toBeDefined()
+  })
+})

--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -68,4 +68,22 @@ describe 'CsvParser' do
     expect(transactions[0].memo).to eq('Coffee Club')
     expect(transactions[1].memo).to eq('Direct Credit')
   end
+
+  it 'does not import pending purchase authorisations from CSV' do
+    csv = <<~CSV
+      Date,Amount,Account Number,,Transaction Type,Transaction Details,Balance,Category,Merchant Name,Processed On
+      12/06/2026,-10.00,123456,,Card Payment,PURCHASE AUTHORISATION,-10.00,Food,Grocer,12/06/2026
+      11/06/2026,-16.00,123456,,Card Payment,Coffee Shop,-26.00,Food,Coffee Shop,11/06/2026
+    CSV
+
+    file = StringIO.new(csv)
+
+    parser = Lib::CsvParser.new file
+    transactions = parser.transactions
+
+    expect(transactions.length).to eq(1)
+    expect(transactions[0].memo).to eq('Coffee Shop')
+    expect(transactions[0].date).to eq(Date.parse('2026-06-11'))
+    expect(transactions[0].amount).to eq(-1600)
+  end
 end

--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -35,4 +35,37 @@ describe 'CsvParser' do
     expect(transactions[1].date).to eq(Date.parse('2016-10-28'))
     expect(transactions[1].amount).to eq(302_099)
   end
+
+  it 'returns the transactions from the People First formatted CSV file' do
+    file = Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/test_people_first.csv'))
+
+    parser = Lib::CsvParser.new file
+    transactions = parser.transactions
+
+    expect(transactions.length).to eq(2)
+
+    expect(transactions[0].memo).to eq('Coffee Shop')
+    expect(transactions[0].date).to eq(Date.parse('2026-06-11'))
+    expect(transactions[0].amount).to eq(-1600)
+    expect(transactions[1].memo).to eq('Direct Credit')
+    expect(transactions[1].date).to eq(Date.parse('2026-06-10'))
+    expect(transactions[1].amount).to eq(382_000)
+  end
+
+  it 'falls back to merchant name then transaction type for People First memo' do
+    csv = <<~CSV
+      Date,Amount,Account Number,,Transaction Type,Transaction Details,Balance,Category,Merchant Name,Processed On
+      11/06/2026,-16.00,123456,,Card Payment,,-100.00,Food,Coffee Club,11/06/2026
+      10/06/2026,3820.00,123456,,Direct Credit,,3720.00,Income,,10/06/2026
+    CSV
+
+    file = StringIO.new(csv)
+
+    parser = Lib::CsvParser.new file
+    transactions = parser.transactions
+
+    expect(transactions.length).to eq(2)
+    expect(transactions[0].memo).to eq('Coffee Club')
+    expect(transactions[1].memo).to eq('Direct Credit')
+  end
 end

--- a/spec/lib/pdf_parser_spec.rb
+++ b/spec/lib/pdf_parser_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lib::PdfParser do
+  let(:file) { StringIO.new('%PDF-FAKE') }
+
+  describe '#transactions' do
+    it 'delegates supported statements to the People First Bank adapter' do
+      parser = described_class.new(file)
+      adapter = instance_double(Lib::PeopleFirstBankPdfAdapter, transactions: ['txn'])
+      allow(parser).to receive(:extract_text).and_return('09/06/2026 Accounts - Retail Banking peoplefirstbank')
+      allow(Lib::PeopleFirstBankPdfAdapter).to receive(:matches?).and_return(true)
+      allow(Lib::PeopleFirstBankPdfAdapter).to receive(:new).with('09/06/2026 Accounts - Retail Banking peoplefirstbank').and_return(adapter)
+
+      expect(parser.transactions).to eq(['txn'])
+    end
+  end
+
+  describe '#extract_text' do
+    it 'uses tempfile when file behaves like ActionDispatch::Http::UploadedFile' do
+      tempfile = StringIO.new('%PDF-FAKE')
+      uploaded_file = instance_double('ActionDispatch::Http::UploadedFile', tempfile: tempfile)
+      parser = described_class.new(uploaded_file)
+      page = instance_double('PDF::Reader::Page', text: 'page one')
+      reader = instance_double('PDF::Reader', pages: [page])
+
+      expect(PDF::Reader).to receive(:new).with(tempfile).and_return(reader)
+
+      expect(parser.send(:extract_text)).to eq('page one')
+    end
+  end
+
+  it 'returns transactions between the results and loaded markers' do
+    parser = described_class.new(file)
+    allow(parser).to receive(:extract_text).and_return(<<~TEXT)
+      01/06/2026, 20:29 Accounts - Retail Banking
+      7 results found
+      Yesterday
+      Osko TfrTo Samantha Matthews
+      -$160.00
+      Dinner Refund
+
+      29 May2026
+      Osko Direct Credit Osko Paul Matthews
+      +$3,820.00
+
+      14 May2026
+      Payroll Credit CultureAmp Pty
+      +$11,486.91
+      all transactions have been loaded.
+      Quick links
+    TEXT
+
+    transactions = parser.transactions
+
+    expect(transactions.length).to eq(3)
+
+    expect(transactions[0].date).to eq(Date.new(2026, 5, 31))
+    expect(transactions[0].memo).to eq('Osko TfrTo Samantha Matthews Dinner Refund')
+    expect(transactions[0].amount).to eq(-16_000)
+
+    expect(transactions[1].date).to eq(Date.new(2026, 5, 29))
+    expect(transactions[1].memo).to eq('Osko Direct Credit Osko Paul Matthews')
+    expect(transactions[1].amount).to eq(382_000)
+
+    expect(transactions[2].date).to eq(Date.new(2026, 5, 14))
+    expect(transactions[2].memo).to eq('Payroll Credit CultureAmp Pty')
+    expect(transactions[2].amount).to eq(1_148_691)
+  end
+
+  it 'returns an empty array when the section markers are missing' do
+    parser = described_class.new(file)
+    allow(parser).to receive(:extract_text).and_return(<<~TEXT)
+      Transactions
+      Osko TfrTo Samantha Matthews
+      -$160.00
+    TEXT
+
+    expect(parser.transactions).to eq([])
+  end
+
+  it 'parses lines where memo and amount are on the same line' do
+    parser = described_class.new(file)
+    allow(parser).to receive(:extract_text).and_return(<<~TEXT)
+      09/06/2026, 19:48 Accounts - Retail Banking
+      2 results found
+      14 May2026
+      IbTfr102893244To 102893246 -$10,000.00
+      Payroll Credit CultureAmp Pty
+      492484 000622 +$11,486.91
+      all transactions have been loaded.
+    TEXT
+
+    transactions = parser.transactions
+
+    expect(transactions.length).to eq(2)
+    expect(transactions[0].date).to eq(Date.new(2026, 5, 14))
+    expect(transactions[0].memo).to eq('IbTfr102893244To 102893246')
+    expect(transactions[0].amount).to eq(-1_000_000)
+
+    expect(transactions[1].date).to eq(Date.new(2026, 5, 14))
+    expect(transactions[1].memo).to eq('Payroll Credit CultureAmp Pty')
+    expect(transactions[1].amount).to eq(1_148_691)
+  end
+
+  it 'parses statements that say singular result found' do
+    parser = described_class.new(file)
+    allow(parser).to receive(:extract_text).and_return(<<~TEXT)
+      09/06/2026, 20:14 Loans - Accounts - Accounts - Retail Banking
+      1 result found
+      31 May2026
+      Interest -$2,014.14
+      all transactions have been loaded.
+    TEXT
+
+    transactions = parser.transactions
+
+    expect(transactions.length).to eq(1)
+    expect(transactions[0].date).to eq(Date.new(2026, 5, 31))
+    expect(transactions[0].memo).to eq('Interest')
+    expect(transactions[0].amount).to eq(-201_414)
+  end
+end

--- a/spec/lib/transaction_importer_spec.rb
+++ b/spec/lib/transaction_importer_spec.rb
@@ -107,5 +107,109 @@ describe Lib::TransactionImporter do
       expect(transactions[0].duplicate).to be_falsey
       expect(transactions[0].import).to be_truthy
     end
+
+    it 'sets duplicate when existing memo differs only by carriage returns' do
+      pdf_parser = instance_double Lib::PdfParser
+      parsed_memo = "Osko Direct Credit Osko Paul\r\nMatthews"
+      existing_memo = 'Osko Direct Credit Osko Paul Matthews'
+      transaction = ImportedTransaction.new(memo: parsed_memo, date:, amount:)
+
+      allow(file).to receive(:original_filename).and_return('file.pdf')
+      allow(Lib::PdfParser).to receive(:new).with(file).and_return(pdf_parser)
+      allow(pdf_parser).to receive(:transactions).and_return([transaction])
+
+      FactoryBot.create(:transaction, account:, memo: existing_memo, date:, amount:)
+
+      transactions = described_class.new(account, file).execute
+
+      expect(transactions.length).to eq(1)
+      expect(transactions[0].duplicate).to be_truthy
+      expect(transactions[0].import).to be_falsey
+    end
+
+    it 'sets duplicate when existing memo has trailing reference tokens' do
+      pdf_parser = instance_double Lib::PdfParser
+      parsed_memo = 'Direct DebitAnz Credit Card'
+      existing_memo = 'Direct DebitAnz Credit Card 024332 4564680122023046'
+      transaction = ImportedTransaction.new(memo: parsed_memo, date:, amount:)
+
+      allow(file).to receive(:original_filename).and_return('file.pdf')
+      allow(Lib::PdfParser).to receive(:new).with(file).and_return(pdf_parser)
+      allow(pdf_parser).to receive(:transactions).and_return([transaction])
+
+      FactoryBot.create(:transaction, account:, memo: existing_memo, date:, amount:)
+
+      transactions = described_class.new(account, file).execute
+
+      expect(transactions.length).to eq(1)
+      expect(transactions[0].duplicate).to be_truthy
+      expect(transactions[0].import).to be_falsey
+    end
+
+    it 'handles ascii-8bit memo encoding without raising errors' do
+      pdf_parser = instance_double Lib::PdfParser
+      parsed_memo = "Direct DebitAnz Credit Card\xC2".b
+      parsed_memo.force_encoding(Encoding::ASCII_8BIT)
+      transaction = ImportedTransaction.new(memo: parsed_memo, date:, amount:)
+
+      allow(file).to receive(:original_filename).and_return('file.pdf')
+      allow(Lib::PdfParser).to receive(:new).with(file).and_return(pdf_parser)
+      allow(pdf_parser).to receive(:transactions).and_return([transaction])
+
+      expect { described_class.new(account, file).execute }.not_to raise_error
+    end
+
+    it 'sets duplicate when imported memo adds a wrapped surname' do
+      pdf_parser = instance_double Lib::PdfParser
+      parsed_memo = "Osko Direct Credit Osko Paul\nMatthews"
+      existing_memo = 'Osko Direct Credit Osko Paul'
+      transaction = ImportedTransaction.new(memo: parsed_memo, date:, amount:)
+
+      allow(file).to receive(:original_filename).and_return('file.pdf')
+      allow(Lib::PdfParser).to receive(:new).with(file).and_return(pdf_parser)
+      allow(pdf_parser).to receive(:transactions).and_return([transaction])
+
+      FactoryBot.create(:transaction, account:, memo: existing_memo, date:, amount:)
+
+      transactions = described_class.new(account, file).execute
+
+      expect(transactions.length).to eq(1)
+      expect(transactions[0].duplicate).to be_truthy
+      expect(transactions[0].import).to be_falsey
+    end
+
+    it 'applies account pattern when memo spans lines' do
+      pdf_parser = instance_double Lib::PdfParser
+      wrapped_memo = "Osko Direct Credit Osko Paul\nMatthews"
+      transaction = ImportedTransaction.new(memo: wrapped_memo, date:, amount:)
+      category = FactoryBot.create(:category)
+      subcategory = FactoryBot.create(:subcategory, category:)
+
+      allow(file).to receive(:original_filename).and_return('file.pdf')
+      allow(Lib::PdfParser).to receive(:new).with(file).and_return(pdf_parser)
+      allow(pdf_parser).to receive(:transactions).and_return([transaction])
+
+      FactoryBot.create(:pattern,
+                        account:,
+                        match_text: 'Osko Direct Credit Osko Paul Matthews',
+                        category:,
+                        subcategory:,
+                        notes: 'Matched wrapped memo')
+
+      other_account = FactoryBot.create(:account)
+      other_category = FactoryBot.create(:category)
+      FactoryBot.create(:pattern,
+                        account: other_account,
+                        match_text: 'Osko Direct Credit Osko Paul Matthews',
+                        category: other_category,
+                        notes: 'Should not be used')
+
+      transactions = described_class.new(account, file).execute
+
+      expect(transactions.length).to eq(1)
+      expect(transactions[0].category_id).to eq(category.id)
+      expect(transactions[0].subcategory_id).to eq(subcategory.id)
+      expect(transactions[0].notes).to eq('Matched wrapped memo')
+    end
   end
 end

--- a/spec/lib/transaction_importer_spec.rb
+++ b/spec/lib/transaction_importer_spec.rb
@@ -88,4 +88,24 @@ describe Lib::TransactionImporter do
       expect(transactions[0].import).to be_truthy
     end
   end
+
+  describe 'pdf file' do
+    it 'returns the parsed transactions' do
+      pdf_parser = instance_double Lib::PdfParser
+      transaction = ImportedTransaction.new(memo:, date:, amount:)
+
+      allow(file).to receive(:original_filename).and_return('file.pdf')
+      allow(Lib::PdfParser).to receive(:new).with(file).and_return(pdf_parser)
+      allow(pdf_parser).to receive(:transactions).and_return([transaction])
+
+      transactions = described_class.new(account, file).execute
+
+      expect(transactions.length).to eq(1)
+      expect(transactions[0].memo).to eq(memo)
+      expect(transactions[0].date).to eq(Date.parse(date))
+      expect(transactions[0].amount).to eq(amount)
+      expect(transactions[0].duplicate).to be_falsey
+      expect(transactions[0].import).to be_truthy
+    end
+  end
 end

--- a/spec/models/lib/recurring_payments_search_spec.rb
+++ b/spec/models/lib/recurring_payments_search_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Lib::RecurringPaymentsSearch do
+  describe '#report' do
+    it 'returns expenses that repeat in at least 3 distinct months with same normalized merchant and amount' do
+      account = FactoryBot.create(:account, account_type: 'savings')
+      date_range = Lib::CustomDateRange.new(from_date: '2026-01-01', to_date: '2026-06-30')
+
+      FactoryBot.create(:transaction, account:, date: '2026-01-04', memo: 'NETFLIX.COM', amount: -1599)
+      FactoryBot.create(:transaction, account:, date: '2026-02-05', memo: 'Netflix com', amount: -1599)
+      FactoryBot.create(:transaction, account:, date: '2026-03-06', memo: 'Netflix-com', amount: -1599)
+
+      FactoryBot.create(:transaction, account:, date: '2026-04-07', memo: 'NETFLIX.COM', amount: -1799)
+      FactoryBot.create(:transaction, account:, date: '2026-02-07', memo: 'ONE OFF', amount: -455)
+      FactoryBot.create(:transaction, account:, date: '2026-01-10', memo: 'SALARY', amount: 100_000)
+
+      result = described_class.new(date_range:).report
+
+      expect(result.length).to eq(1)
+
+      candidate = result[0]
+      expect(['NETFLIX.COM', 'Netflix com', 'Netflix-com']).to include(candidate[:merchant])
+      expect(candidate[:merchant_key]).to eq('netflix com')
+      expect(candidate[:amount]).to eq(-1599)
+      expect(candidate[:months_matched]).to eq(3)
+      expect(candidate[:occurrence_count]).to eq(3)
+      expect(candidate[:first_date]).to eq('2026-01-04')
+      expect(candidate[:last_date]).to eq('2026-03-06')
+      expect(candidate[:monthly_occurrences]).to eq(
+        {
+          '2026-01' => 1,
+          '2026-02' => 1,
+          '2026-03' => 1
+        }
+      )
+      expect(candidate[:transactions].map(&:id).length).to eq(3)
+    end
+
+    it 'counts a month once for threshold even if there are multiple transactions in that month' do
+      account = FactoryBot.create(:account, account_type: 'savings')
+      date_range = Lib::CustomDateRange.new(from_date: '2026-01-01', to_date: '2026-06-30')
+
+      FactoryBot.create(:transaction, account:, date: '2026-01-04', memo: 'Spotify', amount: -1299)
+      FactoryBot.create(:transaction, account:, date: '2026-01-15', memo: 'Spotify', amount: -1299)
+      FactoryBot.create(:transaction, account:, date: '2026-02-05', memo: 'Spotify', amount: -1299)
+      FactoryBot.create(:transaction, account:, date: '2026-03-05', memo: 'Spotify', amount: -1299)
+
+      result = described_class.new(date_range:).report
+
+      expect(result.length).to eq(1)
+      candidate = result[0]
+      expect(candidate[:months_matched]).to eq(3)
+      expect(candidate[:occurrence_count]).to eq(4)
+      expect(candidate[:monthly_occurrences]).to eq(
+        {
+          '2026-01' => 2,
+          '2026-02' => 1,
+          '2026-03' => 1
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Some of the transaction from People First bank have breaks in the transaction memo as they are so long. This was causing a mismatch when trying to do the import.